### PR TITLE
ViewPager added to app

### DIFF
--- a/app/src/main/java/doit/study/dodroid/MainActivity.java
+++ b/app/src/main/java/doit/study/dodroid/MainActivity.java
@@ -2,18 +2,34 @@ package doit.study.dodroid;
 
 import android.app.Activity;
 import android.app.Fragment;
-import android.app.FragmentTransaction;
 import android.os.Bundle;
+import android.support.v4.app.FragmentActivity;
+import android.support.v4.app.FragmentPagerAdapter;
+import android.support.v4.view.PagerAdapter;
+import android.support.v4.view.ViewPager;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentTransaction;
+
 
 // Entry point for the app.
 // Because we set in manifest action=MAIN category=LAUNCHER
-public class MainActivity extends Activity implements MainFragment.OnFragmentInteractionListener {
+public class MainActivity extends FragmentActivity  {
+
+
+
+    private ViewPager mPager;
+    private PagerAdapter mPagerAdapter;
+    private final int PAGE_COUNT = 3; // number of pages/tabs to use for viewpager
 
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+        setContentView(R.layout.viewpager_layout);
+
+        mPager = (ViewPager)findViewById(R.id.view_pager);
+        mPagerAdapter = new MainPagerAdapter(getSupportFragmentManager());
+        mPager.setAdapter(mPagerAdapter);
 
 
         // Check that the activity is using the layout version with
@@ -29,11 +45,25 @@ public class MainActivity extends Activity implements MainFragment.OnFragmentInt
 
             // insert the MainFragment into the Activity as the start of the application
             MainFragment mainFrag = new MainFragment();
-            getFragmentManager()
+            getSupportFragmentManager()
                     .beginTransaction()
                     .add(R.id.fragment_container, mainFrag)
                     .commit();
 
+        }
+    }
+
+
+
+    @Override
+    public void onBackPressed() {
+        if (mPager.getCurrentItem() == 0) {
+            // If the user is currently looking at the first step, allow the system to handle the
+            // Back button. This calls finish() on this activity and pops the back stack.
+            super.onBackPressed();
+        } else {
+            // Otherwise, select the previous step.
+            mPager.setCurrentItem(mPager.getCurrentItem() - 1);
         }
     }
 
@@ -46,28 +76,70 @@ public class MainActivity extends Activity implements MainFragment.OnFragmentInt
     /*
      * This  method would need to be moved out of MainFragment class and into a separate interface if this was to be used for more fragments added to the application later
      */
-    @Override
-    public void replaceFragment(Class frag, Bundle args) {
 
-        Fragment newFrag = null;
 
-        try {
-            newFrag = (Fragment) frag.newInstance();
+    // No need for replaceFragment if using viewpager/swiping, fragment_container returns null then, so can replace fragments based in that container
 
-        } catch (Exception e) {
-            e.printStackTrace();
+//    @Override
+//    public void replaceFragment(Class frag, Bundle args) {
+//
+//        android.support.v4.app.Fragment newFrag = null;
+//
+//        try {
+//            newFrag = (android.support.v4.app.Fragment) frag.newInstance();
+//
+//        } catch (Exception e) {
+//            e.printStackTrace();
+//        }
+//
+//        // Pass arguments if any
+//        if (args != null)
+//            newFrag.setArguments(args);
+//
+//
+//        FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
+//        ft.replace(R.id.fragment_container, newFrag)
+//                .addToBackStack(null)
+//                .commit();
+//
+//    }
+
+
+    private class MainPagerAdapter extends FragmentPagerAdapter{
+
+        public MainPagerAdapter(FragmentManager fm){
+            super(fm);
         }
 
-        // Pass arguments if any
-        if (args != null)
-            newFrag.setArguments(args);
+
+        @Override
+        public android.support.v4.app.Fragment getItem(int position) {
+            switch (position){
+                case 0: return MainFragment.newInstance();
+                case 1: return QuestionsFragment.newInstance();
+                case 2: return TestFragment.newInstance();
+                default: return null;
+            }
+        }
+
+        @Override
+        public int getCount() {
+            return PAGE_COUNT;
+        }
 
 
-        FragmentTransaction ft = getFragmentManager().beginTransaction();
-        ft.replace(R.id.fragment_container, newFrag)
-                .addToBackStack(null)
-                .commit();
 
+        @Override
+        public CharSequence getPageTitle(int position){
+
+            switch (position){
+                case 0: return "Maxin";
+                case 1: return "Loves";
+                case 2: return "Janice";
+                default: return null;
+            }
+        }
     }
+
 
 }

--- a/app/src/main/java/doit/study/dodroid/MainFragment.java
+++ b/app/src/main/java/doit/study/dodroid/MainFragment.java
@@ -1,7 +1,6 @@
 package doit.study.dodroid;
 
 import android.app.Activity;
-import android.app.Fragment;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
@@ -9,6 +8,8 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
 
 import java.util.ArrayList;
 
@@ -37,6 +38,15 @@ public class MainFragment extends Fragment {
     private OnFragmentInteractionListener mCallback;
 
 
+    // Provided stub factory method
+    public static MainFragment newInstance() {
+
+        MainFragment fragment = new MainFragment();
+
+        // add Bundle args if needed here before returning new instance of this class
+
+        return fragment;
+    }
 
     public MainFragment() {
         // Required empty public constructor
@@ -72,13 +82,13 @@ public class MainFragment extends Fragment {
                 startActivity(motivationIntent);
             }
         });
-        doitButton = (Button) view.findViewById(R.id.doit);
-        doitButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                mCallback.replaceFragment(QuestionsFragment.class, null);
-            }
-        });
+//        doitButton = (Button) view.findViewById(R.id.doit);
+//        doitButton.setOnClickListener(new View.OnClickListener() {
+//            @Override
+//            public void onClick(View v) {
+//                mCallback.replaceFragment(QuestionsFragment.class, null);
+//            }
+//        });
 
         return view;
     }
@@ -89,13 +99,13 @@ public class MainFragment extends Fragment {
     public void onAttach(Activity context) {
         super.onAttach(context);
 
-        // try to setup the connection with the hosting Activity so that callback methods can be used for cross fragment communication
-        try{
-            mCallback = (OnFragmentInteractionListener) context;
-        }catch (ClassCastException e) {
-            throw new ClassCastException(getActivity().toString()
-                    + " must implement OnHeadlineSelectedListener");
-        }
+//        // try to setup the connection with the hosting Activity so that callback methods can be used for cross fragment communication
+//        try{
+//            mCallback = (OnFragmentInteractionListener) context;
+//        }catch (ClassCastException e) {
+//            throw new ClassCastException(getActivity().toString()
+//                    + " must implement OnHeadlineSelectedListener");
+//        }
     }
 
     @Override
@@ -116,6 +126,8 @@ public class MainFragment extends Fragment {
      * "http://developer.android.com/training/basics/fragments/communicating.html"
      * >Communicating with Other Fragments</a> for more information.
      */
+
+    // This is not needed for the replacing fragments ability if we are using viewpager, can still implement fucntions for data passing between fragments though
     public interface OnFragmentInteractionListener {
         // TODO: Update argument type and name
 //        public void onFragmentInteraction(Uri uri);

--- a/app/src/main/java/doit/study/dodroid/QuestionsFragment.java
+++ b/app/src/main/java/doit/study/dodroid/QuestionsFragment.java
@@ -1,6 +1,5 @@
 package doit.study.dodroid;
 
-import android.app.Fragment;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.util.Log;
@@ -12,12 +11,13 @@ import android.widget.CheckBox;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
+import android.support.v4.app.Fragment;
 
 import java.util.ArrayList;
 import java.util.Collections;
 
 
-public class QuestionsFragment extends Fragment implements View.OnClickListener {
+public class QuestionsFragment extends android.support.v4.app.Fragment implements View.OnClickListener {
     private final String LOG_TAG = "NSA " + getClass().getName();
     // index for current question
     private Integer mIndex = 0;

--- a/app/src/main/java/doit/study/dodroid/TestFragment.java
+++ b/app/src/main/java/doit/study/dodroid/TestFragment.java
@@ -1,0 +1,55 @@
+package doit.study.dodroid;
+
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.support.v4.app.Fragment;
+
+/**
+ * A simple {@link Fragment} subclass.
+ * Use the {@link TestFragment#newInstance} factory method to
+ * create an instance of this fragment.
+ */
+public class TestFragment extends Fragment {
+    // TODO: Rename parameter arguments, choose names that match
+    // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
+    private static final String ARG_PARAM1 = "param1";
+    private static final String ARG_PARAM2 = "param2";
+
+    // TODO: Rename and change types of parameters
+    private String mParam1;
+    private String mParam2;
+
+
+
+    // TODO: Rename and change types and number of parameters
+    public static TestFragment newInstance() {
+        TestFragment fragment = new TestFragment();
+
+        return fragment;
+    }
+
+    public TestFragment() {
+        // Required empty public constructor
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (getArguments() != null) {
+            mParam1 = getArguments().getString(ARG_PARAM1);
+            mParam2 = getArguments().getString(ARG_PARAM2);
+        }
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        // Inflate the layout for this fragment
+        return inflater.inflate(R.layout.fragment_test_fragment, container, false);
+    }
+
+
+}

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -18,12 +18,12 @@
             android:text="@string/need_motivation_button"
             />
 
-        <Button
-            android:id="@+id/doit"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/doit_button"
-            android:onClick="doitButtonHandler"
-            />
+        <!--<Button-->
+            <!--android:id="@+id/doit"-->
+            <!--android:layout_width="match_parent"-->
+            <!--android:layout_height="wrap_content"-->
+            <!--android:text="@string/doit_button"-->
+            <!--android:onClick="doitButtonHandler"-->
+            <!--/>-->
     </LinearLayout>
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_test_fragment.xml
+++ b/app/src/main/res/layout/fragment_test_fragment.xml
@@ -1,0 +1,13 @@
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="doit.study.dodroid.TestFragment">
+
+    <!-- TODO: Update blank fragment layout -->
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:text="@string/hello_blank_fragment" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/viewpager_layout.xml
+++ b/app/src/main/res/layout/viewpager_layout.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v4.view.ViewPager xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/view_pager"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <android.support.v4.view.PagerTabStrip
+        android:id="@+id/pager_title_strip"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top"
+        android:background="#33b5e5"
+        android:textColor="#fff"
+        android:textSize="20dp"
+        android:paddingTop="10dp"
+        android:paddingBottom="10dp" />
+
+</android.support.v4.view.ViewPager>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,7 @@
     <string name="commit_button">Commit</string>
     <string name="doit_button">Do it!</string>
     <string name="need_motivation_button">Need some motivation</string>
+
+<!-- TODO: Remove or change this placeholder text -->
+    <string name="hello_blank_fragment">Hello blank fragment</string>
 </resources>


### PR DESCRIPTION
So ViewPager is only available through the support library for Android. So all references(imports) to Fragments, FragManager, etc had to be changed to android.support.v4.app.\* to use the ViewPager. I also added tabs to the pager to add navigation. This is by no means suppose to represent some sort of finished idea but it is at least a visual to see how this navigation would work. The button to replace the main fragment with the questions fragment was commented out along with the replaceFragment method because this does not really work with a paging/swiping navigation the way we have it set up right now. So load up the app on your device and you can swipe between fragments now. There is a dummy third fragment I added called TestFragment just to add one more thing to swipe to while I was developing. Let me know if there is anything wrong with the files added, I was having merge issues on my local master branch but reset my "HEAD" commit to now match your master branch Maxim before I created a new branch to add ViewPager.
