### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/app/src/main/java/doit/study/droid/data/JsonParser.java
+++ b/app/src/main/java/doit/study/droid/data/JsonParser.java
@@ -18,6 +18,8 @@ import timber.log.Timber;
 public class JsonParser {
     private static final boolean DEBUG = true;
 
+    private JsonParser() {}
+
     public static List<ParsedQuestion> getQuestions(InputStream inputStream){
         return parseTests(readFile(inputStream));
     }

--- a/app/src/main/java/doit/study/droid/data/Question.java
+++ b/app/src/main/java/doit/study/droid/data/Question.java
@@ -44,6 +44,8 @@ public class Question implements Parcelable {
         public static final String FQ_LAST_VIEWED_AT = NAME + "." + LAST_VIEWED_AT;
         public static final String FQ_STUDIED_AT = NAME + "." + STUDIED_AT;
         public static final String FQ_STATUS = NAME + "." + STATUS;
+
+        private Table() {}
     }
 
     public enum Status {NEW, ADDED, IN_PROGRESS, STUDIED}

--- a/app/src/main/java/doit/study/droid/data/RelationTables.java
+++ b/app/src/main/java/doit/study/droid/data/RelationTables.java
@@ -9,6 +9,8 @@ public class RelationTables {
         // fully qualified names
         public static final String FQ_TAG_ID = NAME + "." + TAG_ID;
         public static final String FQ_QUESTION_ID = NAME + "." + QUESTION_ID;
+
+        private QuestionTag() {}
     }
 
 
@@ -23,4 +25,6 @@ public class RelationTables {
         Question.Table.FQ_WRONG_ANS_CNT,
         Question.Table.FQ_STATUS
     };
+
+    private RelationTables() {}
 }

--- a/app/src/main/java/doit/study/droid/data/Tag.java
+++ b/app/src/main/java/doit/study/droid/data/Tag.java
@@ -18,6 +18,8 @@ public class Tag {
         public static final String QTY_WHEN_STUDIED = "3";
         public static final String TOTAL_COUNTER = "tagTotalCounter";
         public static final String STUDIED_COUNTER = "tagStudiedCounter";
+
+        private Table() {}
     }
 
     public Integer getId() {


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
This pull request removes 150 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava
