### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/app/src/main/java/doit/study/droid/Utils/Views.java
+++ b/app/src/main/java/doit/study/droid/Utils/Views.java
@@ -3,11 +3,11 @@ package doit.study.droid.utils;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public final class Views {
+    private static final AtomicInteger sNextGeneratedId = new AtomicInteger(1);
+
     private Views(){
         // No instances.
     }
-
-    private static final AtomicInteger sNextGeneratedId = new AtomicInteger(1);
 
     /**
      * Generate a value suitable for use in {@link #setId(int)}.

--- a/app/src/main/java/doit/study/droid/data/Question.java
+++ b/app/src/main/java/doit/study/droid/data/Question.java
@@ -12,6 +12,18 @@ import java.util.List;
 
 public class Question implements Parcelable {
 
+    public static final Parcelable.Creator<Question> CREATOR = new Parcelable.Creator<Question>() {
+        @Override
+        public Question createFromParcel(Parcel source) {
+            return new Question(source);
+        }
+
+        @Override
+        public Question[] newArray(int size) {
+            return new Question[size];
+        }
+    };
+
     public static final class Table {
 
         public static final String NAME ="questions";
@@ -57,6 +69,19 @@ public class Question implements Parcelable {
     private List<String> mTags;
     private String mDocRef;
     private Status mStatus;
+
+    protected Question(Parcel in) {
+        this.mId = in.readInt();
+        this.mWrongCounter = in.readInt();
+        this.mRightCounter = in.readInt();
+        this.mText = in.readString();
+        this.mWrongAnswers = in.createStringArrayList();
+        this.mRightAnswers = in.createStringArrayList();
+        this.mTags = in.createStringArrayList();
+        this.mDocRef = in.readString();
+        int tmpMStatus = in.readInt();
+        this.mStatus = tmpMStatus == -1 ? null : Status.values()[tmpMStatus];
+    }
 
     public Question(int id, String text,
                     List<String> wrongAnswers,
@@ -188,29 +213,4 @@ public class Question implements Parcelable {
         dest.writeString(this.mDocRef);
         dest.writeInt(this.mStatus == null ? -1 : this.mStatus.ordinal());
     }
-
-    protected Question(Parcel in) {
-        this.mId = in.readInt();
-        this.mWrongCounter = in.readInt();
-        this.mRightCounter = in.readInt();
-        this.mText = in.readString();
-        this.mWrongAnswers = in.createStringArrayList();
-        this.mRightAnswers = in.createStringArrayList();
-        this.mTags = in.createStringArrayList();
-        this.mDocRef = in.readString();
-        int tmpMStatus = in.readInt();
-        this.mStatus = tmpMStatus == -1 ? null : Status.values()[tmpMStatus];
-    }
-
-    public static final Parcelable.Creator<Question> CREATOR = new Parcelable.Creator<Question>() {
-        @Override
-        public Question createFromParcel(Parcel source) {
-            return new Question(source);
-        }
-
-        @Override
-        public Question[] newArray(int size) {
-            return new Question[size];
-        }
-    };
 }

--- a/app/src/main/java/doit/study/droid/data/Tag.java
+++ b/app/src/main/java/doit/study/droid/data/Tag.java
@@ -20,15 +20,19 @@ public class Tag {
         public static final String STUDIED_COUNTER = "tagStudiedCounter";
     }
 
-    public Integer getId() {
-        return mId;
-    }
-
     private final Integer mId;
     private final String mName;
     private final Integer mQuestionsCounter;
     private final Integer mQuestionsStudied;
     private boolean mSelected;
+
+    public Tag (Integer id, String name, boolean selected, Integer questionsCounter, Integer questionsStudied) {
+        mId = id;
+        mName = name;
+        mSelected = selected;
+        mQuestionsCounter = questionsCounter;
+        mQuestionsStudied = questionsStudied;
+    }
 
     public static Tag newInstance(Cursor c) {
         return new Tag(c.getInt(c.getColumnIndex("_id")),
@@ -38,13 +42,8 @@ public class Tag {
                 c.getInt(c.getColumnIndex(Table.STUDIED_COUNTER)));
     }
 
-
-    public Tag (Integer id, String name, boolean selected, Integer questionsCounter, Integer questionsStudied) {
-        mId = id;
-        mName = name;
-        mSelected = selected;
-        mQuestionsCounter = questionsCounter;
-        mQuestionsStudied = questionsStudied;
+    public Integer getId() {
+        return mId;
     }
 
     @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
This pull request removes 45 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava
