### PR TITLE
squid:S2696 - Instance methods should not write to "static" fields

### DIFF
--- a/app/src/main/java/doit/study/droid/activities/DrawerBaseActivity.java
+++ b/app/src/main/java/doit/study/droid/activities/DrawerBaseActivity.java
@@ -39,10 +39,10 @@ public class DrawerBaseActivity extends AppCompatActivity
             return sVersion;
 
         try {
-            sVersion = getPackageManager().getPackageInfo(getPackageName(), 0).versionName;
+            setsVersion(getPackageManager().getPackageInfo(getPackageName(), 0).versionName);
         } catch (PackageManager.NameNotFoundException e) {
             e.printStackTrace();
-            sVersion = "buggy";
+            setsVersion("buggy");
         }
         return sVersion;
     }
@@ -178,5 +178,11 @@ public class DrawerBaseActivity extends AppCompatActivity
         builder.startActivities();
     }
 
+    public static String getsVersion() {
+        return sVersion;
+    }
 
+    public static void setsVersion(String sVersion) {
+        DrawerBaseActivity.sVersion = sVersion;
+    }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S2696 - Instance methods should not write to "static" fields.
This pull request removes 40 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2696
Please let me know if you have any questions.
George Kankava
