### PR TITLE
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/app/src/main/java/doit/study/droid/adapters/InterrogatorPagerAdapter.java
+++ b/app/src/main/java/doit/study/droid/adapters/InterrogatorPagerAdapter.java
@@ -47,7 +47,7 @@ public class InterrogatorPagerAdapter extends FragmentStatePagerAdapter {
     @Override
     public CharSequence getPageTitle(int position) {
         if (DEBUG) Timber.d("getPageTitle pos: %d, questions: %s", position, mQuestions.get(position));
-        StringBuffer title = new StringBuffer();
+        StringBuilder title = new StringBuilder();
         // at exit pager asks title, cursor invalid
         for (String tag : mQuestions.get(position).getTags())
             title.append(tag).append(" ");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
This pull request removes 20 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1149
Please let me know if you have any questions.
George Kankava
