### PR TITLE
Multiple code improvements - squid:SwitchLastCaseIsDefaultCheck, squid:UselessParenthesesCheck, squid:S1132

### DIFF
--- a/app/src/main/java/doit/study/droid/data/Question.java
+++ b/app/src/main/java/doit/study/droid/data/Question.java
@@ -126,7 +126,7 @@ public class Question implements Parcelable {
     }
 
     private static List<String> splitItems(String s){
-        if (s.equals(""))
+        if ("".equals(s))
             return new ArrayList<>();
         else
             return Arrays.asList(s.split("\n"));

--- a/app/src/main/java/doit/study/droid/data/QuizProvider.java
+++ b/app/src/main/java/doit/study/droid/data/QuizProvider.java
@@ -93,11 +93,11 @@ public class QuizProvider extends ContentProvider {
     @Override
     public String getType(Uri uri) {
         switch (sUriMatcher.match(uri)) {
-            case (RAND_QUESTION_DIR):
+            case RAND_QUESTION_DIR:
                 return QUESTION_TYPE;
             case QUESTION_DIR:
                 return QUESTION_TYPE;
-            case (TAG_DIR):
+            case TAG_DIR:
                 return TAG_TYPE;
             default:
                 throw new UnsupportedOperationException("Unknown uri: " + uri);
@@ -110,15 +110,15 @@ public class QuizProvider extends ContentProvider {
         if (DEBUG) Timber.d("query db: %s %s %s", uri, projection, selectionArgs);
         Cursor cursor;
         switch (sUriMatcher.match(uri)) {
-            case (RAND_QUESTION_DIR): {
+            case RAND_QUESTION_DIR: {
                 cursor = getRandSelectedQuestions(uri, projection);
                 break;
             }
-            case (TAG_DIR): {
+            case TAG_DIR: {
                 cursor = getTags();
                 break;
             }
-            case (QUESTION_DIR): {
+            case QUESTION_DIR: {
                 cursor = getQuestions(uri, projection);
                 break;
             }
@@ -150,6 +150,9 @@ public class QuizProvider extends ContentProvider {
             case QUESTION_DIR: {
                 mod = db.update(Question.Table.NAME, values, selection, selectionArgs);
                 tableName = Question.Table.NAME;
+                break;
+            }
+            default: {
                 break;
             }
         }

--- a/app/src/main/java/doit/study/droid/fragments/InterrogatorFragment.java
+++ b/app/src/main/java/doit/study/droid/fragments/InterrogatorFragment.java
@@ -103,11 +103,11 @@ public class InterrogatorFragment extends LifecycleLogFragment implements View.O
     @Override
     public boolean onOptionsItemSelected(MenuItem menuItem){
         switch(menuItem.getItemId()){
-            case(R.id.doc_reference):{
+            case R.id.doc_reference: {
                 openDocumentation();
                 return true;
             }
-            case(R.id.action_settings):{
+            case R.id.action_settings: {
                 startActivity(new Intent(getContext(), SettingsActivity.class));
                 return true;
             }
@@ -205,7 +205,7 @@ public class InterrogatorFragment extends LifecycleLogFragment implements View.O
     }
 
     private void updateAnswers(Bundle savedInstanceState){
-        boolean isDisabled = (mState == State.ANSWERED_RIGHT || mState == State.ANSWERED_WRONG);
+        boolean isDisabled = mState == State.ANSWERED_RIGHT || mState == State.ANSWERED_WRONG;
 
         if (isDisabled && mvAnswersLayout.getChildCount()!=0) {
             for(CheckBox c: mvCheckBoxes)
@@ -322,14 +322,16 @@ public class InterrogatorFragment extends LifecycleLogFragment implements View.O
     public void onClick(View v) {
         if (DEBUG) Timber.d(String.valueOf(v.getId()));
         switch (v.getId()) {
-            case (R.id.commit_button):
+            case R.id.commit_button:
                 handleCommitButton();
                 break;
-            case (R.id.thump_up_button):
+            case R.id.thump_up_button:
                 handleThumpUpButton();
                 break;
-            case (R.id.thump_down_button):
+            case R.id.thump_down_button:
                 handleThumpDownButton();
+                break;
+            default:
                 break;
         }
     }

--- a/app/src/main/java/doit/study/droid/fragments/TopicsChooserFragment.java
+++ b/app/src/main/java/doit/study/droid/fragments/TopicsChooserFragment.java
@@ -183,6 +183,8 @@ public class TopicsChooserFragment extends Fragment implements LoaderManager.Loa
             case QUESTION_LOADER:
                 if (DEBUG) Timber.d("QUESTION_LOADER Total questions: %d", data.getCount());
                 break;
+            default:
+                break;
         }
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:S1132 - Strings literals should be placed on the left side when checking for equality.
This pull request removes technical debt of 36 minutes.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1132
Please let me know if you have any questions.
George Kankava
