### PR TITLE
squid:S00112 - Generic exceptions should never be thrown

### DIFF
--- a/app/src/main/java/doit/study/droid/Utils/Sound.java
+++ b/app/src/main/java/doit/study/droid/Utils/Sound.java
@@ -38,7 +38,6 @@ public class Sound {
             mSoundsRight = mAssetManager.list(PATH_SOUNDS_RIGHT);
         } catch (IOException e) {
             Timber.e(e, null);
-            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S00112 - Generic exceptions should never be thrown.
This pull request removes 40 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S00112
Please let me know if you have any questions.
George Kankava
