### PR TITLE
squid:S1166 - Exception handlers should preserve the original exception

### DIFF
--- a/app/src/main/java/doit/study/droid/Utils/Distribution.java
+++ b/app/src/main/java/doit/study/droid/Utils/Distribution.java
@@ -3,7 +3,11 @@ package doit.study.droid.utils;
 import android.content.Context;
 import android.content.pm.PackageManager;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 public final class Distribution {
+    private static final Logger logger = Logger.getLogger(Distribution.class.getName());
     private static String sVersion;
 
     private Distribution(){
@@ -17,7 +21,7 @@ public final class Distribution {
         try {
             sVersion = context.getPackageManager().getPackageInfo(context.getPackageName(), 0).versionName;
         } catch (PackageManager.NameNotFoundException e) {
-            e.printStackTrace();
+            logger.log(Level.SEVERE, "PackageManager.NameNotFoundException exception in Distribution.getVersion(Context)", e);
             sVersion = "buggy";
         }
         return sVersion;

--- a/app/src/main/java/doit/study/droid/Utils/Sound.java
+++ b/app/src/main/java/doit/study/droid/Utils/Sound.java
@@ -9,8 +9,11 @@ import android.media.MediaPlayer;
 import java.io.File;
 import java.io.IOException;
 import java.util.Random;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class Sound {
+    private static final Logger logger = Logger.getLogger(Sound.class.getName());
     private final static String PATH_SOUNDS_WRONG = "wrong";
     private final static String PATH_SOUNDS_RIGHT = "right";
     private String[] mSoundsWrong;
@@ -62,7 +65,7 @@ public class Sound {
             mMediaPlayer.prepare();
             mMediaPlayer.start();
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.log(Level.SEVERE, "IOException in Sound.play(boolean)", e);
         }
     }
 

--- a/app/src/main/java/doit/study/droid/data/JsonParser.java
+++ b/app/src/main/java/doit/study/droid/data/JsonParser.java
@@ -11,11 +11,14 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import timber.log.Timber;
 
 // TODO: implement iterator
 public class JsonParser {
+    private static final Logger logger = Logger.getLogger(JsonParser.class.getName());
     private static final boolean DEBUG = true;
 
     private JsonParser() {}
@@ -79,7 +82,7 @@ public class JsonParser {
                 parsedQuestions.add(question);
             }
         } catch (JSONException e) {
-            e.printStackTrace();
+            logger.log(Level.SEVERE, "JSONException in JsonParser.parseTests(String)", e);
         }
         if (DEBUG) Timber.d(parsedQuestions != null ? parsedQuestions.toString() : "none");
         return parsedQuestions;

--- a/app/src/main/java/doit/study/droid/fragments/InterrogatorFragment.java
+++ b/app/src/main/java/doit/study/droid/fragments/InterrogatorFragment.java
@@ -33,6 +33,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import doit.study.droid.BuildConfig;
 import doit.study.droid.R;
@@ -45,6 +47,7 @@ import timber.log.Timber;
 
 
 public class InterrogatorFragment extends LifecycleLogFragment implements View.OnClickListener{
+    private static final Logger logger = Logger.getLogger(InterrogatorFragment.class.getName());
     private static final boolean DEBUG = false;
     private static final int REPORT_DIALOG_REQUEST_CODE = 0;
     public static final String REPORT_DIALOG_TAG = "fragment_dialog_dislike";
@@ -133,6 +136,7 @@ public class InterrogatorFragment extends LifecycleLogFragment implements View.O
         try {
             mOnFragmentActivityChatter = (OnFragmentActivityChatter) activity;
         } catch (ClassCastException e) {
+            logger.log(Level.SEVERE, "ClassCastException in InterrogatorFragment.onAttach(Context)", e);
             throw new ClassCastException(activity.toString()
                     + " must implement OnFragmentActivityChatter");
         }

--- a/app/src/main/java/doit/study/droid/fragments/TopicsChooserFragment.java
+++ b/app/src/main/java/doit/study/droid/fragments/TopicsChooserFragment.java
@@ -24,6 +24,8 @@ import android.view.ViewGroup;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import doit.study.droid.R;
 import doit.study.droid.adapters.TopicAdapter;
@@ -34,6 +36,7 @@ import timber.log.Timber;
 
 
 public class TopicsChooserFragment extends Fragment implements LoaderManager.LoaderCallbacks<Cursor>, SearchView.OnQueryTextListener{
+    private static final Logger logger = Logger.getLogger(TopicsChooserFragment.class.getName());
     private final static boolean DEBUG = false;
     private TopicAdapter mTopicAdapter;
     private RecyclerView mRecyclerView;
@@ -142,7 +145,7 @@ public class TopicsChooserFragment extends Fragment implements LoaderManager.Loa
                     ContentProviderResult[] res = getActivity().getContentResolver().applyBatch(QuizProvider.AUTHORITY, ops);
                     if (DEBUG) Timber.d("Update result: %d", res.length);
                 } catch (RemoteException | OperationApplicationException e) {
-                    e.printStackTrace();
+                    logger.log(Level.SEVERE, "RemoteException | OperationApplicationException in TopicsChooserFragment.onPause()", e);
                 }
             }
             private void appendSelection(StringBuilder s, int id){


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1166 - Exception handlers should preserve the original exception.
This pull request removes 50 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1166
Please let me know if you have any questions.
George Kankava
