### PR TITLE
squid:S1161 - "@Override" annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one

### DIFF
--- a/app/src/main/java/doit/study/droid/Utils/Reversed.java
+++ b/app/src/main/java/doit/study/droid/Utils/Reversed.java
@@ -11,12 +11,16 @@ public class Reversed<T> implements Iterable<T> {
         this.original = original;
     }
 
+    @Override
     public Iterator<T> iterator() {
         final ListIterator<T> i = original.listIterator(original.size());
 
         return new Iterator<T>() {
+            @Override
             public boolean hasNext() { return i.hasPrevious(); }
+            @Override
             public T next() { return i.previous(); }
+            @Override
             public void remove() { i.remove(); }
         };
     }

--- a/app/src/main/java/doit/study/droid/activities/InterrogatorActivity.java
+++ b/app/src/main/java/doit/study/droid/activities/InterrogatorActivity.java
@@ -68,6 +68,7 @@ public class InterrogatorActivity extends DrawerBaseActivity implements Interrog
         final int posInFocus = mPager.getCurrentItem();
         Handler handler = new Handler();
         handler.postDelayed(new Runnable() {
+            @Override
             public void run() {
                 if (posInFocus == mPager.getCurrentItem()) {
                     if (DEBUG) Timber.d("swipe to the next page");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1161 - "@Override" annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one.
This pull request removes 25 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1161
Please let me know if you have any questions.
George Kankava
