### PR TITLE
add debug menu and option to turn on ssl pinning through that menu

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -114,6 +114,9 @@ dependencies {
     implementation "androidx.navigation:navigation-ui-ktx:$navigationVer"
 
     implementation "androidx.lifecycle:lifecycle-common-java8:$lifecycleCommonJava8Ver"
-
+    // used in debug menu to restart application process
+    implementation "com.jakewharton:process-phoenix:$phoenix"
+    // a debug bridge to inspect Database, Network, Sharedpreferences
+    implementation "com.facebook.stetho:stetho:$stetho"
 }
 

--- a/app/src/debug/res/menu/drawer.xml
+++ b/app/src/debug/res/menu/drawer.xml
@@ -29,6 +29,11 @@
         android:id="@+id/settings_fragment_dest"
         android:icon="@drawable/ic_settings"
         android:title="@string/action_settings" />
+
+    <item
+        android:id="@+id/debug_fragment_dest"
+        android:icon="@drawable/ic_debug_menu_24dp"
+        android:title="@string/debug_menu" />
     </group>
 
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
+        android:networkSecurityConfig="@xml/network_security_config"
         tools:ignore="GoogleAppIndexingWarning">
         <activity android:name=".common.MainDrawerActivity" />
         <activity
@@ -20,7 +21,7 @@
             android:theme="@style/SplashTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
+                <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>

--- a/app/src/main/java/doit/study/droid/app/BaseApp.kt
+++ b/app/src/main/java/doit/study/droid/app/BaseApp.kt
@@ -7,6 +7,7 @@ import doit.study.droid.BuildConfig
 import doit.study.droid.di.AppComponent
 import doit.study.droid.di.AppModule
 import doit.study.droid.di.DaggerAppComponent
+import doit.study.droid.di.NetworkModule
 import io.fabric.sdk.android.Fabric
 
 
@@ -14,7 +15,9 @@ abstract class BaseApp : Application() {
 
     override fun onCreate() {
         super.onCreate()
-        dagger = DaggerAppComponent.builder().appModule(AppModule(this)).build()
+        dagger = DaggerAppComponent.builder()
+                .appModule(AppModule(this))
+                .build()
         setupCrashlytics()
     }
 

--- a/app/src/main/java/doit/study/droid/data/local/QuizDatabase.kt
+++ b/app/src/main/java/doit/study/droid/data/local/QuizDatabase.kt
@@ -9,7 +9,7 @@ import doit.study.droid.data.local.entity.Question
 import doit.study.droid.data.local.entity.QuestionTagJoin
 import doit.study.droid.data.local.entity.Tag
 
-@Database(entities = [Question::class, Tag::class, QuestionTagJoin::class], version = 1)
+@Database(entities = [Question::class, Tag::class, QuestionTagJoin::class], version = 2)
 @TypeConverters(Converters::class)
 abstract class QuizDatabase : RoomDatabase() {
     abstract fun questionDao(): QuestionDao

--- a/app/src/main/java/doit/study/droid/data/local/preferences/SslPinning.kt
+++ b/app/src/main/java/doit/study/droid/data/local/preferences/SslPinning.kt
@@ -1,0 +1,18 @@
+package doit.study.droid.data.local.preferences
+
+import android.app.Application
+import androidx.preference.PreferenceManager
+import doit.study.droid.R
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SslPinning @Inject constructor(val appContext: Application) {
+    private val sp = PreferenceManager.getDefaultSharedPreferences(appContext)
+
+    fun isEnabled(): Boolean {
+        return sp.getBoolean(
+                appContext.resources.getString(R.string.debug_pref_ssl_pinning),
+                false)
+    }
+}

--- a/app/src/main/java/doit/study/droid/debug/DebugFragment.kt
+++ b/app/src/main/java/doit/study/droid/debug/DebugFragment.kt
@@ -1,0 +1,37 @@
+package doit.study.droid.debug
+
+import android.os.Bundle
+import androidx.preference.Preference
+import androidx.preference.PreferenceFragmentCompat
+import com.jakewharton.processphoenix.ProcessPhoenix
+import doit.study.droid.R
+
+class DebugFragment() : PreferenceFragmentCompat() {
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        addPreferencesFromResource(R.xml.debug_fragment)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setupMisc()
+        setupNetwork()
+    }
+
+    private fun setupNetwork() {
+        findPreference<Preference>(getString(R.string.debug_pref_ssl_pinning))?.let {
+            it.onPreferenceClickListener = Preference.OnPreferenceClickListener {
+                ProcessPhoenix.triggerRebirth(context)
+                true
+            }
+        }
+    }
+
+    private fun setupMisc() {
+        findPreference<Preference>(getString(R.string.debug_force_crash))?.let {
+            it.onPreferenceClickListener = Preference.OnPreferenceClickListener {
+                throw RuntimeException("forced crash")
+            }
+        }
+    }
+}

--- a/app/src/main/java/doit/study/droid/debug/DebugFragment.kt
+++ b/app/src/main/java/doit/study/droid/debug/DebugFragment.kt
@@ -18,6 +18,11 @@ class DebugFragment() : PreferenceFragmentCompat() {
         setupNetwork()
     }
 
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+        activity?.title = getString(R.string.debug_title_debug_menu)
+    }
+
     private fun setupNetwork() {
         findPreference<Preference>(getString(R.string.debug_pref_ssl_pinning))?.let {
             it.onPreferenceClickListener = Preference.OnPreferenceClickListener {

--- a/app/src/main/java/doit/study/droid/di/NetworkModule.kt
+++ b/app/src/main/java/doit/study/droid/di/NetworkModule.kt
@@ -1,25 +1,40 @@
 package doit.study.droid.di
 
+import android.app.Application
+import androidx.preference.PreferenceManager
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import dagger.Module
 import dagger.Provides
 import doit.study.droid.BuildConfig
+import doit.study.droid.R
+import doit.study.droid.data.local.preferences.SslPinning
 import doit.study.droid.data.remote.QuizDataClient
+import okhttp3.CertificatePinner
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import java.net.URI
 import javax.inject.Singleton
 
 @Module
-class NetworkModule {
+class NetworkModule() {
 
     @Provides
     @Singleton
     internal fun provideGson(): Gson {
         val gsonBuilder = GsonBuilder()
         return gsonBuilder.create()
+    }
+
+    @Provides
+    @Singleton
+    internal fun provideCertPinning(sslPinning: SslPinning): CertificatePinner {
+        val certBuilder = CertificatePinner.Builder()
+        if (sslPinning.isEnabled())
+            certBuilder.add(URI(BASE_URL).host, SUBJECT_PUBLIC_KEY_INFO)
+        return certBuilder.build()
     }
 
     private fun createLogInterceptor(): HttpLoggingInterceptor {
@@ -30,8 +45,9 @@ class NetworkModule {
 
     @Provides
     @Singleton
-    internal fun provideOkHttpClient(): OkHttpClient {
+    internal fun provideOkHttpClient(certificatePinner: CertificatePinner): OkHttpClient {
         val client = OkHttpClient.Builder()
+                .certificatePinner(certificatePinner)
         client.addInterceptor(createLogInterceptor());
         return client.build()
     }
@@ -54,6 +70,8 @@ class NetworkModule {
 
     companion object {
         private const val BASE_URL = "https://dodroid-6f241.web.app/"
+        // note: that Certificate key is valid until Mon, 26 Oct 2020
+        private const val SUBJECT_PUBLIC_KEY_INFO = "sha256/fm0SEuAdUu/JvjeuKT5rUTGp5XibsNski/y43V5JSY8="
     }
 
 

--- a/app/src/main/java/doit/study/droid/settings/SettingsFragment.kt
+++ b/app/src/main/java/doit/study/droid/settings/SettingsFragment.kt
@@ -9,4 +9,8 @@ class SettingsFragment : PreferenceFragmentCompat() {
         addPreferencesFromResource(R.xml.pref_general)
     }
 
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+        activity?.title = getString(R.string.title_settings)
+    }
 }

--- a/app/src/main/java/doit/study/droid/utils/Sound.kt
+++ b/app/src/main/java/doit/study/droid/utils/Sound.kt
@@ -30,8 +30,9 @@ class Sound @Inject constructor(private val context: Application): DefaultLifecy
     private// turn off sound (user may turn it on manually again) if audio list is corrupted
     val isEnabled: Boolean
         get() {
-            val SP = PreferenceManager.getDefaultSharedPreferences(context)
-            val prefEnabled = SP.getBoolean(context.resources.getString(R.string.pref_sound), true)
+            //TODO: extract as an abstraction
+            val sp = PreferenceManager.getDefaultSharedPreferences(context)
+            val prefEnabled = sp.getBoolean(context.resources.getString(R.string.pref_sound), true)
             val audioListLoaded = soundsForWrongAnswer != null && soundsForRightAnswer != null
             if (prefEnabled && !audioListLoaded)
                 displayErrMessageAndTurnOffSound()

--- a/app/src/main/res/drawable/ic_debug_menu_24dp.xml
+++ b/app/src/main/res/drawable/ic_debug_menu_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M20,8h-2.81c-0.45,-0.78 -1.07,-1.45 -1.82,-1.96L17,4.41 15.59,3l-2.17,2.17C12.96,5.06 12.49,5 12,5c-0.49,0 -0.96,0.06 -1.41,0.17L8.41,3 7,4.41l1.62,1.63C7.88,6.55 7.26,7.22 6.81,8L4,8v2h2.09c-0.05,0.33 -0.09,0.66 -0.09,1v1L4,12v2h2v1c0,0.34 0.04,0.67 0.09,1L4,16v2h2.81c1.04,1.79 2.97,3 5.19,3s4.15,-1.21 5.19,-3L20,18v-2h-2.09c0.05,-0.33 0.09,-0.66 0.09,-1v-1h2v-2h-2v-1c0,-0.34 -0.04,-0.67 -0.09,-1L20,10L20,8zM14,16h-4v-2h4v2zM14,12h-4v-2h4v2z"/>
+</vector>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -46,5 +46,10 @@
         android:name="doit.study.droid.settings.SettingsFragment"
         />
 
+    <fragment
+        android:id="@+id/debug_fragment_dest"
+        android:name="doit.study.droid.debug.DebugFragment"
+        />
+
 
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="action_settings">Settings</string>
     <string name="doc_reference">documentation reference</string>
 
+    <string name="title_settings">Settings</string>
     <string name="turn_sound_on">turn on</string>
     <string name="turn_sound_off">turn off</string>
     <string name="pref_sound">pref_sound</string>
@@ -68,6 +69,7 @@
     <string name="failed_to_load_quiz">Failed to load quiz data</string>
     <string name="error_to_sync_try_again_later">Error to sync, try again later</string>
     <!-- for debug menu -->
+    <string name="debug_title_debug_menu">Debug Menu</string>
     <string name="debug_menu">Debug Menu</string>
     <string name="debug_force_crash">debug_force_crash</string>
     <string name="debug_pref_ssl_pinning">debug_pref_ssl_pinning</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,4 +67,8 @@
     <string name="test_completed">Test completed</string>
     <string name="failed_to_load_quiz">Failed to load quiz data</string>
     <string name="error_to_sync_try_again_later">Error to sync, try again later</string>
+    <!-- for debug menu -->
+    <string name="debug_menu">Debug Menu</string>
+    <string name="debug_force_crash">debug_force_crash</string>
+    <string name="debug_pref_ssl_pinning">debug_pref_ssl_pinning</string>
 </resources>

--- a/app/src/main/res/xml/debug_fragment.xml
+++ b/app/src/main/res/xml/debug_fragment.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <PreferenceCategory android:title="Network">
+
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/debug_pref_ssl_pinning"
+            android:summaryOff="Turn on SSL pinning and restart"
+            android:summaryOn="Turn off SSL pinning and restart"
+            android:title="SSL pinning" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="Misc">
+        <Preference
+            android:key="@string/debug_force_crash"
+            android:summary="Clicking this forces the app to crash."
+            android:title="Force crash" />
+
+    </PreferenceCategory>
+
+</PreferenceScreen>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config>
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+    <debug-overrides>
+        <trust-anchors>
+            <certificates src="user" />
+        </trust-anchors>
+    </debug-overrides>
+</network-security-config>
+

--- a/build.gradle
+++ b/build.gradle
@@ -57,5 +57,6 @@ ext {
     constraintLayoutVer = "1.1.3"
     navigationVer = "2.1.0"
     lifecycleCommonJava8Ver = "2.1.0"
-
+    phoenix = "2.0.0"
+    stetho = "1.5.1"
 }


### PR DESCRIPTION
Connected tickets:
Add debug menu https://github.com/mgolokhov/dodroid/issues/145
Add option to turn on ssl pinning https://github.com/mgolokhov/dodroid/issues/144

The man-in-the-middle attack can be emulated with Charles tool.
<img src="https://user-images.githubusercontent.com/294512/70814298-3eb0b480-1ddc-11ea-86b5-7dbd9ffef891.png" width="300" />

For Android 7+ [security config was added](https://github.com/mgolokhov/dodroid/blob/5999cd9c36b227b8d81007f61a136ccf137554b0/app/src/main/res/xml/network_security_config.xml) 

To turn on SSL ping use debug menu:
<img src="https://user-images.githubusercontent.com/294512/70814619-e7f7aa80-1ddc-11ea-9955-5fea6c325037.jpg" width="200" />
